### PR TITLE
Use an Edge Function for SSR instead of Middleware

### DIFF
--- a/edge-entry.js
+++ b/edge-entry.js
@@ -5,19 +5,7 @@ import indexTemplate from './dist/client/index.html?raw';
 import {ReadableStream} from 'web-streams-polyfill/ponyfill';
 Object.assign(globalThis, {ReadableStream});
 
-function isAsset(url) {
-  return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname);
-}
-
-export default async function middleware(request, event) {
-  const url = new URL(request.url);
-  if (isAsset(url)) {
-    // Continue with Vercel's default asset handler
-    return new Response(null, {
-      headers: {'x-middleware-next': '1'},
-    });
-  }
-
+export default async (request, event) => {
   try {
     return await handleRequest(request, {
       indexTemplate,

--- a/output-template/config.json
+++ b/output-template/config.json
@@ -2,9 +2,11 @@
   "version": 3,
   "routes": [
     {
+      "handle": "filesystem"
+    },
+    {
       "src": "/(.*)",
-      "middlewarePath": "hydrogen",
-      "continue": true
+      "dest": "hydrogen"
     }
   ]
 }


### PR DESCRIPTION
Using a Middleware for the server-side render is not necessary. We can skip the middleware invocation for static assets by using a vanilla Edge Function.